### PR TITLE
Point to NVidia git repos, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 Linux_for_Tegra/
 aarch64--glibc--stable-2022.08-1/
 out/
-install/
+
+alvium_install/
+alvium_install.tar.bz2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+Linux_for_Tegra/
+aarch64--glibc--stable-2022.08-1/
+out/
+install/

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,11 +5,11 @@
 	url = https://github.com/alliedvision/nvidia-oot.git
 	path = nvidia-oot
 [submodule "nvidia-hwpm"]
-	url = https://github.com/alliedvision/nvidia-hwpm.git
+	url = https://nv-tegra.nvidia.com/r/linux-hwpm.git
 	path = nvidia-hwpm
 [submodule "nvidia-nvethernetrm"]
-	url = https://github.com/alliedvision/nvidia-nvethernetrm.git
+	url = https://nv-tegra.nvidia.com/r/kernel/nvethernetrm.git
 	path = nvidia-nvethernetrm
 [submodule "nvidia-nvgpu"]
-	url = https://github.com/alliedvision/nvidia-nvgpu.git
+	url = https://nv-tegra.nvidia.com/r/linux-nvgpu.git
 	path = nvidia-nvgpu

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,17 @@ NVIDIA_CONFTEST ?= $(MAKEFILE_DIR)/out/nvidia-conftest
 all: nvidia-nvgpu-modules nvidia-oot-modules alvium-driver-modules 
 install: nvidia-modules-install alvium-driver-modules-install
 
+# Build a tarball for installation on Nano
+# Some serious tar black magic for transforming the absolute INSTALL_MOD_PATH
+# to the relative path install/
+# Need -P option to _not_ strip the leading slash, 
+# so the regex (which includes the leading slash) works
+package: install
+	install -m 755 install.sh $(INSTALL_MOD_PATH)
+	tar --transform "flags=r;s|$(INSTALL_MOD_PATH)|install|" -Pcjf alvium_install.tar.bz2  $(INSTALL_MOD_PATH)
+
 alvium-driver-modules: nvidia-oot-modules
-	$(MAKE) \
+	$(MAKE)  -j $(NPROC) \
 		KBUILD_EXTRA_SYMBOLS=$(MAKEFILE_DIR)/nvidia-oot/Module.symvers \
 		CONFIG_TEGRA_OOT_MODULE=y \
 		srctree.nvidia-oot=$(MAKEFILE_DIR)/nvidia-oot \
@@ -22,7 +31,7 @@ alvium-driver-modules-install: alvium-driver-modules
 		-C $(MAKEFILE_DIR)/alvium-csi2-driver install
 
 
-nvidia-oot-conftest:
+nvidia-oot-conftest: check-env
 	mkdir -p $(NVIDIA_CONFTEST)/nvidia;
 	cp -av $(MAKEFILE_DIR)/nvidia-oot/scripts/conftest/* $(NVIDIA_CONFTEST)/nvidia
 	$(MAKE) -j $(NPROC) ARCH=arm64 \
@@ -33,7 +42,7 @@ nvidia-oot-conftest:
 		-f $(NVIDIA_CONFTEST)/nvidia/Makefile
 		
 nvidia-hwpm-modules: nvidia-oot-conftest
-	$(MAKE) \
+	$(MAKE)  -j $(NPROC) \
 		CONFIG_TEGRA_OOT_MODULE=m \
 		srctree.hwpm=$(MAKEFILE_DIR)/nvidia-hwpm \
 		srctree.nvconftest=$(NVIDIA_CONFTEST) \
@@ -53,7 +62,7 @@ nvidia-hwpm-modules-install: nvidia-hwpm-modules
 		
 nvidia-oot-modules: nvidia-oot-conftest nvidia-hwpm-modules
 	cp -av $(MAKEFILE_DIR)/nvidia-nvethernetrm $(MAKEFILE_DIR)/nvidia-oot/drivers/net/ethernet/nvidia/nvethernet/nvethernetrm
-	$(MAKE) \
+	$(MAKE)  -j $(NPROC) \
 		CONFIG_TEGRA_OOT_MODULE=m \
 		srctree.nvidia-oot=$(MAKEFILE_DIR)/nvidia-oot \
 		srctree.nvconftest=$(NVIDIA_CONFTEST) \
@@ -75,7 +84,7 @@ nvidia-oot-modules-install: nvidia-oot-modules
 		modules_install
 
 nvidia-nvgpu-modules: nvidia-oot-modules nvidia-oot-conftest
-	$(MAKE) \
+	$(MAKE) -j $(NPROC) \
 		CONFIG_TEGRA_OOT_MODULE=m \
 		KBUILD_EXTRA_SYMBOLS=$(MAKEFILE_DIR)/nvidia-oot/Module.symvers \
 		srctree.nvidia-oot=$(MAKEFILE_DIR)/nvidia-oot \
@@ -97,6 +106,23 @@ nvidia-nvgpu-modules-install: nvidia-nvgpu-modules
 		modules_install
 
 nvidia-modules-install: nvidia-nvgpu-modules-install nvidia-oot-modules-install nvidia-hwpm-modules-install
+
+
+check-env:
+ifndef ARCH
+      $(error Environment variable ARCH must be defined)
+endif
+ifndef CROSS_COMPILE
+      $(error Environment variable CROSS_COMPILE must be defined)
+endif
+ifndef KERNEL_SRC
+      $(error Environment variable KERNEL_SRC must be defined)
+endif
+	if [ ! -d "$(KERNEL_SRC)" ]; then \
+        echo "$(KERNEL_SRC) does not exist!"; \
+        exit 1; \
+    fi
+
 
 clean: 
 	rm -rf out/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,63 @@
-# Allied Vision Alvium CSI driver for Jetpack 6 
+# Trisect-specific Allied Vision Alvium CSI driver for Jetpack 6 
+
+Derived from the upstream Allied Vision [Alvium CSI Driver for Jetpack 6](https://github.com/alliedvision/alvium-jetson-driver-release) with local modifications specific to the [Trisect project](https://trisect-perception-sensor.gitlab.io/trisect-docs/).
+
+
+## Building
+
+1. Clone this repository **including all submodules**
+
+    ```shell
+        git clone --recurse-submodules https://github.com/apl-ocean-engineering/alvium-jetson-driver-release.git
+    ```
+
+    or:
+
+    ```shell
+        git clone https://github.com/apl-ocean-engineering/alvium-jetson-driver-release.git
+        git submodule update --init
+    ```
+
+2. Download the Jetson Linux driver package (BSP) and cross compiler (registration with Nvidia required).   The driver package / BSP  **must** match your version of Jetpack:
+
+    * [Downloads for Jetpack 6.0 / Linux4Tegra 36.3](https://developer.nvidia.com/embedded/jetson-linux-r363)
+
+3. Extract the driver package **in the current directory**: 
+
+    ```shell
+        tar -xvf jetson_linux_r36*.bz2
+    ```
+4. Extract the kernel headers from the driver package:
+
+    ```shell
+        cd Linux_for_Tegra/kernel/
+        tar -xvf kernel_headers.tbz2
+    ```
+5. Extract the cross compiler **in the current directory**
+
+    ```shell
+        tar -xvf aarch64--glibc--stable-*.tar.bz2
+    ```
+
+6. Build the modules:
+    ```shell
+        export ARCH=arm64
+        export CROSS_COMPILE=<path to cross compiler>/bin/aarch64-buildroot-linux-gnu-
+        export KERNEL_SRC=Linux_for_Tegra/kernel/linux-headers-*-linux_x86_64/3rdparty/canonical/linux-jammy/kernel-source/
+        make all 
+    ```
+7. Install the driver modules
+    ```shell
+        export INSTALL_MOD_PATH=<path to install directory>
+        make install
+    ```
+
+
+
+
+
+
+
 
 ## Compatibility
 ### SoMs + Carrier Boards 
@@ -28,31 +87,6 @@
     6. Select "Save and reboot to reconfigure pins"
 4. After the board has reboot the camera can be access with V4L2 and Vimba X
 
-## Building
-1. Clone this repository including all submodules
-2. Download the Jetson Linux driver package and cross compiler from: [Jetson Linux Downloads](https://developer.nvidia.com/embedded/jetson-linux)
-3. Extract the driver package: 
-    ```shell
-        tar -xf jetson_linux_r36*.bz2
-    ```
-4. Extract the kernel headers from the driver package:
-    ```shell
-        cd Linux_for_Tegra/kernel/
-        tar -xf kernel_headers.tbz2
-    ```
-5. Extract the cross compiler
-6. Build the modules:
-    ```shell
-        export ARCH=arm64
-        export CROSS_COMPILE=<path to cross compiler>/bin/aarch64-buildroot-linux-gnu-
-        export KERNEL_SRC=Linux_for_Tegra/kernel/linux-headers-*-linux_x86_64/3rdparty/canonical/linux-jammy/kernel-source/
-        make all 
-    ```
-7. Install the driver modules
-    ```shell
-        export INSTALL_MOD_PATH=<path to install directory>
-        make install
-    ```
    
 # Beta Disclaimer
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/sh
+#
+# Install script which is added to install.tar.bz2 by "make package"
+
+sudo install -o root -g root -m 644 boot/* /boot
+sudo find lib/modules/5.15.136-tegra/updates/ -type f -print -exec install -D -o root -g root -m 644 \{\} /\{\} \;
+sudo depmod -a

--- a/setup.sh
+++ b/setup.sh
@@ -9,4 +9,4 @@ export CROSS_COMPILE=$(pwd)/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildro
 # see the README
 export KERNEL_SRC=$(pwd)/Linux_for_Tegra/kernel/linux-headers-5.15.136-tegra-linux_x86_64/3rdparty/canonical/linux-jammy/kernel-source
 
-export INSTALL_MOD_PATH=$(pwd)/install
+export INSTALL_MOD_PATH=$(pwd)/alvium_install

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+export ARCH=arm64
+
+# Assumes the cross compiler package has been unpacked in the current directory;
+# see the README
+export CROSS_COMPILE=$(pwd)/aarch64--glibc--stable-2022.08-1/bin/aarch64-buildroot-linux-gnu-
+
+# Assumes the BSP has been unpacked in the current directory,
+# and kernel_sources.tar.bz2 has been unpacked in Linux_for_Tegra/kernel/
+# see the README
+export KERNEL_SRC=$(pwd)/Linux_for_Tegra/kernel/linux-headers-5.15.136-tegra-linux_x86_64/3rdparty/canonical/linux-jammy/kernel-source
+
+export INSTALL_MOD_PATH=$(pwd)/install


### PR DESCRIPTION
Starting from the upstream Allied Vision code at 36.3, brings the development cycle inline with the development process developed in [vc-jetson-driver-release](https://github.com/apl-ocean-engineering/vc-jetson-driver-release):

This includes:

* Points the submodules for `nvidia-hwpm`, `nvidia-nvethernetrm` and `nvidia-nvgpu`  to the Nvidia repos rather than AVT's forks.
* Adds setup.sh to set environment variables
* Add .gitignore
* Adds our hacky install process.